### PR TITLE
Fix AuthISpec

### DIFF
--- a/it/auth/AuthISpec.scala
+++ b/it/auth/AuthISpec.scala
@@ -64,7 +64,7 @@ class AuthISpec extends IntegrationBaseSpec {
         override def setupStubs(): StubMapping = AuthStub.unauthorisedNotLoggedIn()
 
         val response: WSResponse = await(request().delete())
-        response.status shouldBe FORBIDDEN
+        response.status shouldBe UNAUTHORIZED
       }
     }
 
@@ -73,7 +73,7 @@ class AuthISpec extends IntegrationBaseSpec {
         override def setupStubs(): StubMapping = AuthStub.unauthorisedOther()
 
         val response: WSResponse = await(request().delete())
-        response.status shouldBe FORBIDDEN
+        response.status shouldBe UNAUTHORIZED
       }
     }
   }


### PR DESCRIPTION
In other APIs, AuthISpec mocks mtd-identifier-lookup and so bypasses its own auth check, thereby exposing the API's own failure handling which switches a 401 to 403. This API does not use mtd-identifier-lookup and so a 401 should be returned (consistent with acceptance tests).