### PR TITLE
Fix agent authorisation

### DIFF
--- a/app/api/controllers/AuthorisedController.scala
+++ b/app/api/controllers/AuthorisedController.scala
@@ -21,8 +21,6 @@ import api.models.errors._
 import api.services.EnrolmentsAuthService
 import play.api.libs.json.Json
 import play.api.mvc._
-import uk.gov.hmrc.auth.core.Enrolment
-import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
@@ -40,12 +38,11 @@ abstract class AuthorisedController(cc: ControllerComponents)(implicit ec: Execu
 
     override protected def executionContext: ExecutionContext = cc.executionContext
 
-    def predicate: Predicate = Enrolment("HMRC-MTD-IT") or Enrolment("HMRC-AS-AGENT")
 
     override def invokeBlock[A](request: Request[A], block: UserRequest[A] => Future[Result]): Future[Result] = {
       implicit val headerCarrier: HeaderCarrier = hc(request)
 
-      authService.authorised(predicate).flatMap[Result] {
+      authService.authorised.flatMap[Result] {
         case Right(userDetails) => block(UserRequest(userDetails, request))
         case Left(error) =>
           val result = error match {

--- a/app/api/controllers/AuthorisedController.scala
+++ b/app/api/controllers/AuthorisedController.scala
@@ -40,7 +40,7 @@ abstract class AuthorisedController(cc: ControllerComponents)(implicit ec: Execu
 
     override protected def executionContext: ExecutionContext = cc.executionContext
 
-    def predicate: Predicate = Enrolment("HMRC-MTD-IT")
+    def predicate: Predicate = Enrolment("HMRC-MTD-IT") or Enrolment("HMRC-AS-AGENT")
 
     override def invokeBlock[A](request: Request[A], block: UserRequest[A] => Future[Result]): Future[Result] = {
       implicit val headerCarrier: HeaderCarrier = hc(request)

--- a/test/api/controllers/AuthorisedControllerSpec.scala
+++ b/test/api/controllers/AuthorisedControllerSpec.scala
@@ -64,7 +64,7 @@ class AuthorisedControllerSpec extends ControllerBaseSpec {
         s"the service returns an error with code ${error.code}" must {
           s"return a ${error.httpStatus} with code ${error.code}" in new Test {
             MockedEnrolmentsAuthService
-              .authorised(predicate)
+              .authorised
               .returns(Future.successful(Left(error)))
 
             private val result = target.action()(fakeGetRequest)
@@ -80,7 +80,7 @@ class AuthorisedControllerSpec extends ControllerBaseSpec {
     "auth returns an unexpected error" should {
       "return a 500" in new Test {
         MockedEnrolmentsAuthService
-          .authorised(predicate)
+          .authorised
           .returns(Future.successful(Left(InternalError)))
 
         private val result = target.action()(fakeGetRequest)

--- a/test/api/controllers/AuthorisedControllerSpec.scala
+++ b/test/api/controllers/AuthorisedControllerSpec.scala
@@ -45,7 +45,7 @@ class AuthorisedControllerSpec extends ControllerBaseSpec {
     lazy val target = new TestController()
   }
 
-  val predicate: Predicate = Enrolment("HMRC-MTD-IT")
+  val predicate: Predicate = Enrolment("HMRC-MTD-IT") or Enrolment("HMRC-AS-AGENT")
 
   "calling an action" when {
 

--- a/test/api/mocks/services/MockEnrolmentsAuthService.scala
+++ b/test/api/mocks/services/MockEnrolmentsAuthService.scala
@@ -21,7 +21,6 @@ import api.models.outcomes.AuthOutcome
 import api.services.EnrolmentsAuthService
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
-import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -34,15 +33,15 @@ trait MockEnrolmentsAuthService extends MockFactory {
 
     def authoriseUser(): Unit = {
       (mockEnrolmentsAuthService
-        .authorised(_: Predicate)(_: HeaderCarrier, _: ExecutionContext))
-        .expects(*, *, *)
+        .authorised(_: HeaderCarrier, _: ExecutionContext))
+        .expects(*, *)
         .returns(Future.successful(Right(UserDetails("Individual", None))))
     }
 
-    def authorised(predicate: Predicate): CallHandler[Future[AuthOutcome]] = {
+    def authorised: CallHandler[Future[AuthOutcome]] = {
       (mockEnrolmentsAuthService
-        .authorised(_: Predicate)(_: HeaderCarrier, _: ExecutionContext))
-        .expects(predicate, *, *)
+        .authorised(_: HeaderCarrier, _: ExecutionContext))
+        .expects(*, *)
     }
 
   }


### PR DESCRIPTION
Agent auth was failing when auth was expecting agents to have direct mtd enrolment. A delegated enrolment (used in other APIs failed because there is no NINO and so MTD ID here). 
