### PR TITLE
MTDSA 17146: Migrate to Scala 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This API allows a developer to:
 
 ### Requirements 
 
-- Scala 2.12.x
+- Scala 2.13.x
 - Java 11
 - sbt 1.7.x
 - [Service Manager](https://github.com/hmrc/service-manager)

--- a/app/api/controllers/requestParsers/validators/Validator.scala
+++ b/app/api/controllers/requestParsers/validators/Validator.scala
@@ -31,8 +31,8 @@ trait Validator[A <: RawData] {
       case Nil => List()
       case thisLevel :: remainingLevels =>
         thisLevel(data).flatten match {
-          case x if x.isEmpty  => run(remainingLevels, data)
           case x if x.nonEmpty => x
+          case _               => run(remainingLevels, data)
         }
     }
   }

--- a/app/api/controllers/requestParsers/validators/validations/JsonFormatValidation.scala
+++ b/app/api/controllers/requestParsers/validators/validations/JsonFormatValidation.scala
@@ -49,7 +49,7 @@ object JsonFormatValidation {
     } else {
       data.validate[A] match {
         case JsSuccess(a, _)                                          => Right(a)
-        case JsError(errors: Seq[(JsPath, Seq[JsonValidationError])]) => Left(handleErrors(errors))
+        case JsError(errors) => Left(handleErrors(errors.map(e => (e._1, e._2.toList)).toList))
       }
     }
   }

--- a/app/definition/ApiDefinition.scala
+++ b/app/definition/ApiDefinition.scala
@@ -71,7 +71,7 @@ case class APIDefinition(name: String,
   require(uniqueVersions, "version numbers must be unique")
 
   private def uniqueVersions: Boolean = {
-    !versions.map(_.version).groupBy(identity).mapValues(_.size).exists(_._2 > 1)
+    !versions.map(_.version).groupBy(identity).view.mapValues(_.size).exists(_._2 > 1)
   }
 
 }

--- a/app/utils/enums/Values.scala
+++ b/app/utils/enums/Values.scala
@@ -30,11 +30,12 @@ object Values {
   object MkValues {
 
     implicit def values[E, Impls <: Coproduct](implicit
-        @nowarn("msg=parameter value gen") gen: Generic.Aux[E, Impls],
-        v: Aux[E, Impls]): MkValues[E] =
+         @nowarn("msg=is never used") gen: Generic.Aux[E, Impls],
+        v: Aux[E, Impls]): MkValues[E] = {
       new MkValues[E] {
         def values: List[E] = v.values
       }
+    }
 
     trait Aux[E, Impls] {
       def values: List[E]

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,8 @@ lazy val microservice = Project(appName, file("."))
     scalaVersion := "2.13.11",
     scalacOptions ++= Seq(
       "-Xfatal-warnings",
-      "-Wconf:src=routes/.*:silent"
+      "-Wconf:src=routes/.*:silent",
+      "-Wconf:cat=lint-byname-implicit:s"
     )
   )
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test(),
     retrieveManaged := true,
     update / evictionWarningOptions := EvictionWarningOptions.default.withWarnScalaVersionEviction(warnScalaVersionEviction = false),
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.11",
     scalacOptions ++= Seq(
       "-Xfatal-warnings",
       "-Wconf:src=routes/.*:silent"

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test(),
     retrieveManaged := true,
     update / evictionWarningOptions := EvictionWarningOptions.default.withWarnScalaVersionEviction(warnScalaVersionEviction = false),
-    scalaVersion := "2.12.16",
+    scalaVersion := "2.13.8",
     scalacOptions ++= Seq(
       "-Xfatal-warnings",
       "-Wconf:src=routes/.*:silent"

--- a/test/api/mocks/MockIdGenerator.scala
+++ b/test/api/mocks/MockIdGenerator.scala
@@ -25,7 +25,6 @@ trait MockIdGenerator extends MockFactory {
   val mockIdGenerator: IdGenerator = mock[IdGenerator]
 
   object MockIdGenerator {
-    def getCorrelationId: CallHandler[String] = (mockIdGenerator.getCorrelationId _).expects()
-  }
+    def getCorrelationId: CallHandler[String] = (() => mockIdGenerator.getCorrelationId).expects()  }
 
 }

--- a/test/api/utils/JsonErrorValidators.scala
+++ b/test/api/utils/JsonErrorValidators.scala
@@ -46,7 +46,7 @@ trait JsonErrorValidators {
   implicit class JsResultOps[T](res: JsResult[T]) {
 
     def errors: JsErrors = res match {
-      case JsError(jsErrors) => jsErrors
+      case JsError(jsErrors) => jsErrors.map(error => (error._1, error._2.toList)).toList
       case JsSuccess(_, _)   => fail("A JSON error was expected")
     }
   }
@@ -139,6 +139,7 @@ trait JsonErrorValidators {
       case (path, err :: Nil) if jsError.path == path => err
       case (path, _ :: Nil)                           => fail(s"single error returned but path $path does not match $jsPath")
       case (path, errs @ _ :: _)                      => fail(s"multiple errors returned for $path but only 1 required : $errs")
+      case _                                          => fail(s"unrecognised error(s) returned")
     }
   }
 }

--- a/test/definition/ApiDefinitionFactorySpec.scala
+++ b/test/definition/ApiDefinitionFactorySpec.scala
@@ -36,13 +36,12 @@ class ApiDefinitionFactorySpec extends UnitSpec {
   "definition" when {
     "called" should {
       "return a valid Definition case class" in new Test {
-        MockAppConfig.featureSwitches returns Configuration.empty anyNumberOfTimes ()
+        MockAppConfig.featureSwitches.returns(Configuration.empty).anyNumberOfTimes()
         MockAppConfig.apiStatus("1.0") returns "BETA"
-        MockAppConfig.endpointsEnabled("1.0") returns true anyNumberOfTimes ()
-        MockAppConfig.confidenceLevelCheckEnabled returns ConfidenceLevelConfig(
-          confidenceLevel = confidenceLevel,
-          definitionEnabled = true,
-          authValidationEnabled = true) anyNumberOfTimes ()
+        MockAppConfig.endpointsEnabled("1.0").returns(true).anyNumberOfTimes()
+        MockAppConfig.confidenceLevelCheckEnabled
+          .returns(ConfidenceLevelConfig(confidenceLevel = confidenceLevel, definitionEnabled = true, authValidationEnabled = true))
+          .anyNumberOfTimes()
 
         private val readScope  = "read:self-assessment"
         private val writeScope = "write:self-assessment"

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -27,17 +27,17 @@ trait MockAppConfig extends MockFactory {
 
   object MockAppConfig {
     // Stub Config
-    def stubBaseUrl: CallHandler[String]                         = (mockAppConfig.stubBaseUrl _: () => String).expects()
-    def stubEnvironmentHeaders: CallHandler[Option[Seq[String]]] = (mockAppConfig.stubEnvironmentHeaders _).expects()
+    def stubBaseUrl: CallHandler[String]                         = (()=>mockAppConfig.stubBaseUrl).expects()
+    def stubEnvironmentHeaders: CallHandler[Option[Seq[String]]] = (()=>mockAppConfig.stubEnvironmentHeaders).expects()
 
     // API Config
-    def featureSwitches: CallHandler[Configuration]             = (mockAppConfig.featureSwitches _: () => Configuration).expects()
-    def apiGatewayContext: CallHandler[String]                  = (mockAppConfig.apiGatewayContext _: () => String).expects()
+    def featureSwitches: CallHandler[Configuration]             = (()=> mockAppConfig.featureSwitches).expects()
+    def apiGatewayContext: CallHandler[String]                  = (()=> mockAppConfig.apiGatewayContext).expects()
     def apiStatus(status: String): CallHandler[String]          = (mockAppConfig.apiStatus: String => String).expects(status)
     def endpointsEnabled(version: String): CallHandler[Boolean] = (mockAppConfig.endpointsEnabled: String => Boolean).expects(version)
 
     def confidenceLevelCheckEnabled: CallHandler[ConfidenceLevelConfig] =
-      (mockAppConfig.confidenceLevelConfig _: () => ConfidenceLevelConfig).expects()
+      (()=> mockAppConfig.confidenceLevelConfig).expects()
 
   }
 

--- a/test/routing/VersionRoutingRequestHandlerSpec.scala
+++ b/test/routing/VersionRoutingRequestHandlerSpec.scala
@@ -68,7 +68,7 @@ class VersionRoutingRequestHandlerSpec extends UnitSpec with Inside with MockApp
     val httpConfiguration: HttpConfiguration = HttpConfiguration("context")
     private val errorHandler                 = mock[HttpErrorHandler]
     private val filters                      = mock[HttpFilters]
-    (filters.filters _).stubs().returns(Seq.empty)
+    (() => filters.filters).stubs().returns(Seq.empty)
 
     MockAppConfig.featureSwitches.returns(Configuration(ConfigFactory.parseString("""
                                                                            |version-1.enabled = true

--- a/test/utils/EmptinessCheckerSpec.scala
+++ b/test/utils/EmptinessCheckerSpec.scala
@@ -20,8 +20,6 @@ import support.UnitSpec
 import utils.EmptinessChecker._
 import EmptyPathsResult._
 
-import scala.annotation.nowarn
-
 class EmptinessCheckerSpec extends UnitSpec {
 
   sealed trait SomeEnum
@@ -44,7 +42,6 @@ class EmptinessCheckerSpec extends UnitSpec {
   "EmptinessChecker" when {
     "empty object" must {
       "return root path as empty" in {
-        @nowarn("cat=lint-byname-implicit")
         val result = EmptinessChecker.findEmptyPaths(Foo())
 
         result shouldBe CompletelyEmpty
@@ -54,7 +51,6 @@ class EmptinessCheckerSpec extends UnitSpec {
     "all arrays and objects are non empty" must {
       "return empty" in {
         val barFull = Bar(baz = Some(Baz(Some(1))))
-        @nowarn("cat=lint-byname-implicit")
         val result = EmptinessChecker.findEmptyPaths(Foo(bar = Some(barFull), arr1 = Some(List(barFull))))
 
         result shouldBe NoEmptyPaths
@@ -63,7 +59,6 @@ class EmptinessCheckerSpec extends UnitSpec {
 
     "has an empty object" must {
       "return a path" in {
-        @nowarn("cat=lint-byname-implicit")
         val result = EmptinessChecker.findEmptyPaths(Foo(bar = Some(Bar())))
 
         result shouldBe EmptyPaths(List("/bar"))
@@ -72,7 +67,6 @@ class EmptinessCheckerSpec extends UnitSpec {
 
     "has empty object nested" must {
       "return the path" in {
-        @nowarn("cat=lint-byname-implicit")
         val result = EmptinessChecker.findEmptyPaths(Foo(bar = Some(Bar(Some(Baz())))))
 
         result shouldBe EmptyPaths(List("/bar/baz"))
@@ -81,7 +75,6 @@ class EmptinessCheckerSpec extends UnitSpec {
 
     "has empty list" must {
       "return the path of the list" in {
-        @nowarn("cat=lint-byname-implicit")
         val result = EmptinessChecker.findEmptyPaths(Foo(arr1 = Some(List())))
 
         result shouldBe EmptyPaths(List("/arr1"))
@@ -90,7 +83,6 @@ class EmptinessCheckerSpec extends UnitSpec {
 
     "has empty list nested" must {
       "return the path of the list" in {
-        @nowarn("cat=lint-byname-implicit")
         val result = EmptinessChecker.findEmptyPaths(Foo(bar = Some(Bar(arr = Some(List())))))
 
         result shouldBe EmptyPaths(List("/bar/arr"))
@@ -99,7 +91,6 @@ class EmptinessCheckerSpec extends UnitSpec {
 
     "has empty objects inside list" must {
       "return the paths" in {
-        @nowarn("cat=lint-byname-implicit")
         val result = EmptinessChecker.findEmptyPaths(Foo(arr2 = Some(List(Bar(Some(Baz())), Bar(Some(Baz()))))))
 
         result shouldBe EmptyPaths(List("/arr2/0/baz", "/arr2/1/baz"))
@@ -108,7 +99,6 @@ class EmptinessCheckerSpec extends UnitSpec {
 
     "has multiple empty objects" must {
       "return an error with the paths for all of them" in {
-        @nowarn("cat=lint-byname-implicit")
         val result = EmptinessChecker.findEmptyPaths(
           Foo(bar = Some(Bar(Some(Baz()))), arr1 = Some(Nil), arr2 = Some(List(Bar())), arr3 = Some(List(Bar(Some(Baz())))), bar2 = Some(Bar())))
 

--- a/test/utils/EmptinessCheckerSpec.scala
+++ b/test/utils/EmptinessCheckerSpec.scala
@@ -18,8 +18,9 @@ package utils
 
 import support.UnitSpec
 import utils.EmptinessChecker._
-
 import EmptyPathsResult._
+
+import scala.annotation.nowarn
 
 class EmptinessCheckerSpec extends UnitSpec {
 
@@ -43,56 +44,75 @@ class EmptinessCheckerSpec extends UnitSpec {
   "EmptinessChecker" when {
     "empty object" must {
       "return root path as empty" in {
-        EmptinessChecker.findEmptyPaths(Foo()) shouldBe CompletelyEmpty
+        @nowarn("cat=lint-byname-implicit")
+        val result = EmptinessChecker.findEmptyPaths(Foo())
+
+        result shouldBe CompletelyEmpty
       }
     }
 
     "all arrays and objects are non empty" must {
       "return empty" in {
         val barFull = Bar(baz = Some(Baz(Some(1))))
-        EmptinessChecker.findEmptyPaths(Foo(bar = Some(barFull), arr1 = Some(List(barFull)))) shouldBe NoEmptyPaths
+        @nowarn("cat=lint-byname-implicit")
+        val result = EmptinessChecker.findEmptyPaths(Foo(bar = Some(barFull), arr1 = Some(List(barFull))))
+
+        result shouldBe NoEmptyPaths
       }
     }
 
     "has an empty object" must {
-      "return an path" in {
-        EmptinessChecker.findEmptyPaths(Foo(bar = Some(Bar()))) shouldBe EmptyPaths(List("/bar"))
+      "return a path" in {
+        @nowarn("cat=lint-byname-implicit")
+        val result = EmptinessChecker.findEmptyPaths(Foo(bar = Some(Bar())))
+
+        result shouldBe EmptyPaths(List("/bar"))
       }
     }
 
     "has empty object nested" must {
       "return the path" in {
-        EmptinessChecker.findEmptyPaths(Foo(bar = Some(Bar(Some(Baz()))))) shouldBe EmptyPaths(List("/bar/baz"))
+        @nowarn("cat=lint-byname-implicit")
+        val result = EmptinessChecker.findEmptyPaths(Foo(bar = Some(Bar(Some(Baz())))))
+
+        result shouldBe EmptyPaths(List("/bar/baz"))
       }
     }
 
     "has empty list" must {
       "return the path of the list" in {
-        EmptinessChecker.findEmptyPaths(Foo(arr1 = Some(List()))) shouldBe EmptyPaths(List("/arr1"))
+        @nowarn("cat=lint-byname-implicit")
+        val result = EmptinessChecker.findEmptyPaths(Foo(arr1 = Some(List())))
+
+        result shouldBe EmptyPaths(List("/arr1"))
       }
     }
 
     "has empty list nested" must {
       "return the path of the list" in {
-        EmptinessChecker.findEmptyPaths(Foo(bar = Some(Bar(arr = Some(List()))))) shouldBe EmptyPaths(List("/bar/arr"))
+        @nowarn("cat=lint-byname-implicit")
+        val result = EmptinessChecker.findEmptyPaths(Foo(bar = Some(Bar(arr = Some(List())))))
+
+        result shouldBe EmptyPaths(List("/bar/arr"))
       }
     }
 
     "has empty objects inside list" must {
       "return the paths" in {
-        EmptinessChecker.findEmptyPaths(Foo(arr2 = Some(List(Bar(Some(Baz())), Bar(Some(Baz())))))) shouldBe
-          EmptyPaths(List("/arr2/0/baz", "/arr2/1/baz"))
+        @nowarn("cat=lint-byname-implicit")
+        val result = EmptinessChecker.findEmptyPaths(Foo(arr2 = Some(List(Bar(Some(Baz())), Bar(Some(Baz()))))))
+
+        result shouldBe EmptyPaths(List("/arr2/0/baz", "/arr2/1/baz"))
       }
     }
 
     "has multiple empty objects" must {
       "return an error with the paths for all of them" in {
-        EmptinessChecker.findEmptyPaths(Foo(bar = Some(Bar(Some(Baz()))),
-                                            arr1 = Some(Nil),
-                                            arr2 = Some(List(Bar())),
-                                            arr3 = Some(List(Bar(Some(Baz())))),
-                                            bar2 = Some(Bar()))) shouldBe
-          EmptyPaths(List("/bar/baz", "/arr1", "/arr2/0", "/arr3/0/baz", "/bar2"))
+        @nowarn("cat=lint-byname-implicit")
+        val result = EmptinessChecker.findEmptyPaths(
+          Foo(bar = Some(Bar(Some(Baz()))), arr1 = Some(Nil), arr2 = Some(List(Bar())), arr3 = Some(List(Bar(Some(Baz())))), bar2 = Some(Bar())))
+
+        result shouldBe EmptyPaths(List("/bar/baz", "/arr1", "/arr2/0", "/arr3/0/baz", "/bar2"))
       }
     }
   }


### PR DESCRIPTION
Migration to Scala 2.13.8 was almost entirely modelled on the main API team's PRs to migrate to scala 2.13. See for example [this PR](https://github.com/hmrc/property-business-api/pull/399) in property-business-api.

Migration to Scala 2.13.11 only required a minor change to a "noWarn" statement, because the phrasing of the suppressed warning message had changed slightly.  

