### PR TITLE
MTDSA-29698 Update Create a Test Business for the migration of IFS to HIP of API#1171 for Business Details API

### DIFF
--- a/app/uk/gov/hmrc/mtdsatestsupportapi/models/request/createTestBusiness/Business.scala
+++ b/app/uk/gov/hmrc/mtdsatestsupportapi/models/request/createTestBusiness/Business.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package uk.gov.hmrc.mtdsatestsupportapi.models.request.createTestBusiness
 
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
-import utils.enums.Enums
 
 import java.time.LocalDate
 
@@ -56,14 +55,13 @@ object Business {
   private implicit val typeOfBusinessWrites: Writes[TypeOfBusiness] = {
     import TypeOfBusiness._
 
-    val defaultWrites: Writes[TypeOfBusiness] = Enums.writes[TypeOfBusiness]
-
     (typeOfBusiness: TypeOfBusiness) => {
-      val propertyIncomeJson = Json.obj("propertyIncome" -> typeOfBusiness.isProperty)
+      val propertyIncomeJson = Json.obj("propertyIncomeFlag" -> typeOfBusiness.isProperty)
 
       typeOfBusiness match {
-        case `uk-property` | `foreign-property` => propertyIncomeJson + ("incomeSourceType" -> Json.toJson(typeOfBusiness)(defaultWrites))
-        case _                                  => propertyIncomeJson
+        case `uk-property`      => propertyIncomeJson + ("incomeSourceType" -> JsString("02"))
+        case `foreign-property` => propertyIncomeJson + ("incomeSourceType" -> JsString("03"))
+        case _                  => propertyIncomeJson
       }
     }
   }
@@ -75,8 +73,8 @@ object Business {
       (__ \ "firstAccountingPeriodEndDate").writeNullable[LocalDate] and
       (__ \ "latencyDetails").writeNullable[LatencyDetails] and
       (__ \ "quarterTypeElection").writeNullable[QuarterlyTypeChoice] and
-      (__ \ "cashOrAccruals").writeNullable[AccountingType] and
-      (__ \ "tradingStartDate").writeNullable[LocalDate] and
+      (__ \ "cashOrAccrualsFlag").writeNullable[AccountingType] and
+      (__ \ "tradingSDate").writeNullable[LocalDate] and
       (__ \ "cessationDate").writeNullable[LocalDate] and
       (__ \ "businessAddressDetails" \ "addressLine1").writeNullable[String] and
       (__ \ "businessAddressDetails" \ "addressLine2").writeNullable[String] and

--- a/test/uk/gov/hmrc/mtdsatestsupportapi/fixtures/CreateTestBusinessFixtures.scala
+++ b/test/uk/gov/hmrc/mtdsatestsupportapi/fixtures/CreateTestBusinessFixtures.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,17 +27,16 @@ trait CreateTestBusinessFixtures {
 
     object SelfEmployment {
 
-      val mtdBusinessJson: JsObject = Json
-        .parse(
-          """{
-            |  "typeOfBusiness": "self-employment",
-            |  "tradingName": "Self Employed Name",
-            |  "businessAddressLineOne": "Line 1 of address",
-            |  "businessAddressCountryCode": "FR"
-            |}
-            |""".stripMargin
-        )
-        .as[JsObject]
+      val mtdBusinessJson: JsObject = Json.parse(
+        """
+          |{
+          |  "typeOfBusiness": "self-employment",
+          |  "tradingName": "Self Employed Name",
+          |  "businessAddressLineOne": "Line 1 of address",
+          |  "businessAddressCountryCode": "FR"
+          |}
+        """.stripMargin
+      ).as[JsObject]
 
       val business: Business = Business(
         typeOfBusiness = TypeOfBusiness.`self-employment`,
@@ -57,31 +56,30 @@ trait CreateTestBusinessFixtures {
         businessAddressCountryCode = Some("FR")
       )
 
-      val downstreamBusinessJson: JsObject = Json
-        .parse(
-          """{
-            |  "propertyIncome": false,
-            |  "tradingName": "Self Employed Name",
-            |  "businessAddressDetails": {
-            |    "addressLine1": "Line 1 of address",
-            |    "countryCode": "FR"
-            |  }
-            |}""".stripMargin
-        )
-        .as[JsObject]
+      val downstreamBusinessJson: JsObject = Json.parse(
+        """
+          |{
+          |  "propertyIncomeFlag": false,
+          |  "tradingName": "Self Employed Name",
+          |  "businessAddressDetails": {
+          |    "addressLine1": "Line 1 of address",
+          |    "countryCode": "FR"
+          |  }
+          |}
+        """.stripMargin
+      ).as[JsObject]
 
     }
 
     object UkProperty {
 
-      val mtdBusinessJson: JsObject = Json
-        .parse(
-          """{
-            |  "typeOfBusiness": "uk-property"
-            |}
-            |""".stripMargin
-        )
-        .as[JsObject]
+      val mtdBusinessJson: JsObject = Json.parse(
+        """
+          |{
+          |  "typeOfBusiness": "uk-property"
+          |}
+        """.stripMargin
+      ).as[JsObject]
 
       val business: Business = Business(
         typeOfBusiness = TypeOfBusiness.`uk-property`,
@@ -101,13 +99,13 @@ trait CreateTestBusinessFixtures {
         businessAddressCountryCode = None
       )
 
-      val downstreamBusinessJson: JsObject = Json
-        .parse(
-          """{
-            |  "propertyIncome": true
-            |}""".stripMargin
-        )
-        .as[JsObject]
+      val downstreamBusinessJson: JsObject = Json.parse(
+        """
+          |{
+          |  "propertyIncomeFlag": true
+          |}
+        """.stripMargin
+      ).as[JsObject]
 
     }
 

--- a/test/uk/gov/hmrc/mtdsatestsupportapi/models/request/createTestBusiness/BusinessSpec.scala
+++ b/test/uk/gov/hmrc/mtdsatestsupportapi/models/request/createTestBusiness/BusinessSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,33 +74,36 @@ class BusinessSpec extends UnitSpec with CreateTestBusinessFixtures {
       "deserialized from the API JSON" when {
         "all fields present" must {
           "work" in {
-            val mtdJson = Json.parse("""{
-                                       |  "typeOfBusiness": "self-employment",
-                                       |  "tradingName": "Abc Ltd",
-                                       |  "firstAccountingPeriodStartDate": "2002-02-02",
-                                       |  "firstAccountingPeriodEndDate": "2012-12-12",
-                                       |  "latencyDetails": {
-                                       |    "latencyEndDate": "2020-01-01",
-                                       |    "taxYear1": "2020-21",
-                                       |    "latencyIndicator1": "A",
-                                       |    "taxYear2": "2021-22",
-                                       |    "latencyIndicator2": "Q"
-                                       |  },
-                                       |  "quarterlyTypeChoice":{
-                                       |    "quarterlyPeriodType": "standard",
-                                       |    "taxYearOfChoice": "2023-24"
-                                       |  },
-                                       |  "accountingType": "CASH",
-                                       |  "commencementDate": "2000-01-01",
-                                       |  "cessationDate": "2030-01-01",
-                                       |  "businessAddressLineOne": "L1",
-                                       |  "businessAddressLineTwo": "L2",
-                                       |  "businessAddressLineThree": "L3",
-                                       |  "businessAddressLineFour": "L4",
-                                       |  "businessAddressPostcode": "PostCode",
-                                       |  "businessAddressCountryCode": "UK"
-                                       |}
-                                       |""".stripMargin)
+            val mtdJson = Json.parse(
+              """
+                |{
+                |  "typeOfBusiness": "self-employment",
+                |  "tradingName": "Abc Ltd",
+                |  "firstAccountingPeriodStartDate": "2002-02-02",
+                |  "firstAccountingPeriodEndDate": "2012-12-12",
+                |  "latencyDetails": {
+                |    "latencyEndDate": "2020-01-01",
+                |    "taxYear1": "2020-21",
+                |    "latencyIndicator1": "A",
+                |    "taxYear2": "2021-22",
+                |    "latencyIndicator2": "Q"
+                |  },
+                |  "quarterlyTypeChoice": {
+                |    "quarterlyPeriodType": "standard",
+                |    "taxYearOfChoice": "2023-24"
+                |  },
+                |  "accountingType": "CASH",
+                |  "commencementDate": "2000-01-01",
+                |  "cessationDate": "2030-01-01",
+                |  "businessAddressLineOne": "L1",
+                |  "businessAddressLineTwo": "L2",
+                |  "businessAddressLineThree": "L3",
+                |  "businessAddressLineFour": "L4",
+                |  "businessAddressPostcode": "PostCode",
+                |  "businessAddressCountryCode": "UK"
+                |}
+              """.stripMargin
+            )
 
             mtdJson.as[Business] shouldBe businessWithMaxFields(`self-employment`)
           }
@@ -126,42 +129,45 @@ class BusinessSpec extends UnitSpec with CreateTestBusinessFixtures {
 
         def testSerializeToBackend(typeOfBusiness: TypeOfBusiness,
                                    expectedIncomeSourceType: Option[String],
-                                   expectedPropertyIncome: Boolean): Unit = {
+                                   expectedPropertyIncomeFlag: Boolean): Unit = {
           s"typeOfBusiness is $typeOfBusiness" must {
-            "work and set propertyIncome and incomeSourceType correctly" in {
+            "work and set propertyIncomeFlag and incomeSourceType correctly" in {
               val downstreamJson = Json.toJson(businessWithMaxFields(typeOfBusiness))
               val expected = {
                 expectedIncomeSourceType.map(x => Json.obj("incomeSourceType" -> x)).getOrElse(JsObject.empty) ++
                   Json
-                    .parse(s"""{
-                         |  "propertyIncome": $expectedPropertyIncome,
-                         |  "tradingName": "Abc Ltd",
-                         |  "firstAccountingPeriodStartDate": "2002-02-02",
-                         |  "firstAccountingPeriodEndDate": "2012-12-12",
-                         |  "latencyDetails": {
-                         |    "latencyEndDate": "2020-01-01",
-                         |    "taxYear1": "2021",
-                         |    "latencyIndicator1": "A",
-                         |    "taxYear2": "2022",
-                         |    "latencyIndicator2": "Q"
-                         |  },
-                         |  "quarterTypeElection":{
-                         |    "quarterReportingType": "STANDARD",
-                         |    "taxYearofElection": "2024"
-                         |  },
-                         |  "cashOrAccruals": false,
-                         |  "tradingStartDate": "2000-01-01",
-                         |  "cessationDate": "2030-01-01",
-                         |  "businessAddressDetails": {
-                         |    "addressLine1": "L1",
-                         |    "addressLine2": "L2",
-                         |    "addressLine3": "L3",
-                         |    "addressLine4": "L4",
-                         |    "postalCode": "PostCode",
-                         |    "countryCode": "UK"
-                         |  }
-                         |}""".stripMargin)
-                    .as[JsObject]
+                    .parse(
+                      s"""
+                        |{
+                        |  "propertyIncomeFlag": $expectedPropertyIncomeFlag,
+                        |  "tradingName": "Abc Ltd",
+                        |  "firstAccountingPeriodStartDate": "2002-02-02",
+                        |  "firstAccountingPeriodEndDate": "2012-12-12",
+                        |  "latencyDetails": {
+                        |    "latencyEndDate": "2020-01-01",
+                        |    "taxYear1": "2021",
+                        |    "latencyIndicator1": "A",
+                        |    "taxYear2": "2022",
+                        |    "latencyIndicator2": "Q"
+                        |  },
+                        |  "quarterTypeElection": {
+                        |    "quarterReportingType": "STANDARD",
+                        |    "taxYearofElection": "2024"
+                        |  },
+                        |  "cashOrAccrualsFlag": false,
+                        |  "tradingSDate": "2000-01-01",
+                        |  "cessationDate": "2030-01-01",
+                        |  "businessAddressDetails": {
+                        |    "addressLine1": "L1",
+                        |    "addressLine2": "L2",
+                        |    "addressLine3": "L3",
+                        |    "addressLine4": "L4",
+                        |    "postalCode": "PostCode",
+                        |    "countryCode": "UK"
+                        |  }
+                        |}
+                      """.stripMargin
+                    ).as[JsObject]
               }
 
               downstreamJson shouldBe expected
@@ -169,10 +175,10 @@ class BusinessSpec extends UnitSpec with CreateTestBusinessFixtures {
           }
         }
 
-        testSerializeToBackend(`foreign-property`, expectedIncomeSourceType = Some("foreign-property"), expectedPropertyIncome = true)
-        testSerializeToBackend(`uk-property`, expectedIncomeSourceType = Some("uk-property"), expectedPropertyIncome = true)
-        testSerializeToBackend(`property-unspecified`, expectedIncomeSourceType = None, expectedPropertyIncome = true)
-        testSerializeToBackend(`self-employment`, expectedIncomeSourceType = None, expectedPropertyIncome = false)
+        testSerializeToBackend(`foreign-property`, expectedIncomeSourceType = Some("03"), expectedPropertyIncomeFlag = true)
+        testSerializeToBackend(`uk-property`, expectedIncomeSourceType = Some("02"), expectedPropertyIncomeFlag = true)
+        testSerializeToBackend(`property-unspecified`, expectedIncomeSourceType = None, expectedPropertyIncomeFlag = true)
+        testSerializeToBackend(`self-employment`, expectedIncomeSourceType = None, expectedPropertyIncomeFlag = false)
 
       }
     }


### PR DESCRIPTION
This is to update the Test Support API which is used to create a test business for the retrieval endpoint stateful scenarios. The code has been updated to reflect the changes in the latest downstream HIP spec.