### PR TITLE
[MTDSA-30279]: Amend Accounting Type to support ACCRUAL

### DIFF
--- a/app/uk/gov/hmrc/mtdsatestsupportapi/models/request/createTestBusiness/AccountingType.scala
+++ b/app/uk/gov/hmrc/mtdsatestsupportapi/models/request/createTestBusiness/AccountingType.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.mtdsatestsupportapi.models.request.createTestBusiness
 
-import play.api.libs.json.{JsBoolean, Reads, Writes}
+import play.api.libs.json.{JsString, Reads, Writes}
 import utils.enums.Enums
 
 sealed trait AccountingType
@@ -28,8 +28,8 @@ object AccountingType {
   implicit val reads: Reads[AccountingType] = Enums.reads[AccountingType]
 
   implicit val writes: Writes[AccountingType] = {
-    case AccountingType.CASH     => JsBoolean(false)
-    case AccountingType.ACCRUALS => JsBoolean(true)
+    case AccountingType.CASH     => JsString("CASH")
+    case AccountingType.ACCRUALS => JsString("ACCRUAL")
   }
 
   implicit val parser: PartialFunction[String, AccountingType] = Enums.parser[AccountingType]

--- a/test/stubs/WireMockMethods.scala
+++ b/test/stubs/WireMockMethods.scala
@@ -61,7 +61,7 @@ trait WireMockMethods {
 
     def withRequestBody[T](body: T)(implicit writes: Writes[T]): MappingBuilder = {
       val stringBody = writes.writes(body).toString()
-      mappingBuilder.withRequestBody(equalTo(stringBody))
+      mappingBuilder.withRequestBody(equalToJson(stringBody))
       this
     }
 

--- a/test/uk/gov/hmrc/mtdsatestsupportapi/fixtures/CreateTestBusinessFixtures.scala
+++ b/test/uk/gov/hmrc/mtdsatestsupportapi/fixtures/CreateTestBusinessFixtures.scala
@@ -64,7 +64,12 @@ trait CreateTestBusinessFixtures {
           |  "businessAddressDetails": {
           |    "addressLine1": "Line 1 of address",
           |    "countryCode": "FR"
-          |  }
+          |  },
+          |  "selfEmployments": [
+          |     {
+          |      "accountingType": "CASH"
+          |     }
+          |  ]
           |}
         """.stripMargin
       ).as[JsObject]
@@ -98,14 +103,6 @@ trait CreateTestBusinessFixtures {
         businessAddressPostcode = None,
         businessAddressCountryCode = None
       )
-
-      val downstreamBusinessJson: JsObject = Json.parse(
-        """
-          |{
-          |  "propertyIncomeFlag": true
-          |}
-        """.stripMargin
-      ).as[JsObject]
 
     }
 

--- a/test/uk/gov/hmrc/mtdsatestsupportapi/models/request/createTestBusiness/AccountingTypeSpec.scala
+++ b/test/uk/gov/hmrc/mtdsatestsupportapi/models/request/createTestBusiness/AccountingTypeSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.mtdsatestsupportapi.models.request.createTestBusiness
 
-import play.api.libs.json.{JsBoolean, JsString, Json}
+import play.api.libs.json.{JsString, Json}
 import support.UnitSpec
 
 class AccountingTypeSpec extends UnitSpec {
@@ -31,8 +31,8 @@ class AccountingTypeSpec extends UnitSpec {
 
     "serialized to downstream JSON" must {
       "work" in {
-        Json.toJson[AccountingType](AccountingType.CASH) shouldBe JsBoolean(false)
-        Json.toJson[AccountingType](AccountingType.ACCRUALS) shouldBe JsBoolean(true)
+        Json.toJson[AccountingType](AccountingType.CASH) shouldBe JsString("CASH")
+        Json.toJson[AccountingType](AccountingType.ACCRUALS) shouldBe JsString("ACCRUAL")
       }
     }
   }

--- a/test/uk/gov/hmrc/mtdsatestsupportapi/models/request/createTestBusiness/BusinessSpec.scala
+++ b/test/uk/gov/hmrc/mtdsatestsupportapi/models/request/createTestBusiness/BusinessSpec.scala
@@ -92,7 +92,7 @@ class BusinessSpec extends UnitSpec with CreateTestBusinessFixtures {
                 |    "quarterlyPeriodType": "standard",
                 |    "taxYearOfChoice": "2023-24"
                 |  },
-                |  "accountingType": "CASH",
+                |  "accountingType": "ACCRUALS",
                 |  "commencementDate": "2000-01-01",
                 |  "cessationDate": "2030-01-01",
                 |  "businessAddressLineOne": "L1",
@@ -128,6 +128,7 @@ class BusinessSpec extends UnitSpec with CreateTestBusinessFixtures {
       "serialized to downstream JSON" when {
 
         def testSerializeToBackend(typeOfBusiness: TypeOfBusiness,
+                                   expectedTypeOfBusiness: String,
                                    expectedIncomeSourceType: Option[String],
                                    expectedPropertyIncomeFlag: Boolean): Unit = {
           s"typeOfBusiness is $typeOfBusiness" must {
@@ -154,7 +155,11 @@ class BusinessSpec extends UnitSpec with CreateTestBusinessFixtures {
                         |    "quarterReportingType": "STANDARD",
                         |    "taxYearofElection": "2024"
                         |  },
-                        |  "cashOrAccrualsFlag": false,
+                        |  "$expectedTypeOfBusiness":[
+                        |    {
+                        |      "accountingType":"ACCRUAL"
+                        |    }
+                        |  ],
                         |  "tradingSDate": "2000-01-01",
                         |  "cessationDate": "2030-01-01",
                         |  "businessAddressDetails": {
@@ -175,10 +180,10 @@ class BusinessSpec extends UnitSpec with CreateTestBusinessFixtures {
           }
         }
 
-        testSerializeToBackend(`foreign-property`, expectedIncomeSourceType = Some("03"), expectedPropertyIncomeFlag = true)
-        testSerializeToBackend(`uk-property`, expectedIncomeSourceType = Some("02"), expectedPropertyIncomeFlag = true)
-        testSerializeToBackend(`property-unspecified`, expectedIncomeSourceType = None, expectedPropertyIncomeFlag = true)
-        testSerializeToBackend(`self-employment`, expectedIncomeSourceType = None, expectedPropertyIncomeFlag = false)
+        testSerializeToBackend(`foreign-property`, "foreignProperty", expectedIncomeSourceType = Some("03"), expectedPropertyIncomeFlag = true)
+        testSerializeToBackend(`uk-property`, "ukProperty", expectedIncomeSourceType = Some("02"), expectedPropertyIncomeFlag = true)
+        testSerializeToBackend(`property-unspecified`, "ukProperty", expectedIncomeSourceType = None, expectedPropertyIncomeFlag = true)
+        testSerializeToBackend(`self-employment`, "selfEmployments", expectedIncomeSourceType = None, expectedPropertyIncomeFlag = false)
 
       }
     }
@@ -211,7 +216,7 @@ class BusinessSpec extends UnitSpec with CreateTestBusinessFixtures {
         )),
       quarterlyTypeChoice =
         Some(QuarterlyTypeChoice(quarterlyPeriodType = QuarterlyPeriodType.`standard`, taxYearOfChoice = TaxYear.fromMtd("2023-24"))),
-      accountingType = Some(AccountingType.CASH),
+      accountingType = Some(AccountingType.ACCRUALS),
       commencementDate = Some(LocalDate.parse("2000-01-01")),
       cessationDate = Some(LocalDate.parse("2030-01-01")),
       businessAddressLineOne = Some("L1"),


### PR DESCRIPTION
This PR addresses the following issues in regard to the new Accounting Type endpoints. But before that, please find two images that highlight the problem identified at a high level in regard to testing of the new endpoints e.g. Retrieve Accounting Type (In the stateful scenario for example):

**THE PROBLEM:**
<img width="1468" alt="the-problem" src="https://github.com/user-attachments/assets/b6aef8f2-9d9e-41e7-a038-06e0a8db5638" />


**THE SOLUTION**
<img width="1376" alt="the-solution" src="https://github.com/user-attachments/assets/aa6b83fc-a72e-4d3f-bc69-7b63e53bac16" />


The problems identified were as follows: 

1. Given we were creating two new endpoints that expect `ACCRUAL` instead of `ACCRUALS`, we needed to create a test business first via the `test-support-api` first before we could `Update Accounting Type` or `Retrieve Accounting Type` of an existing business.
2. We also needed to make sure that `Retrieve Business Details` in v1 & v2 would still work using the `test-support-api` so the call was to make the change from `ACCRUALS` to `ACCRUAL` in the `test-support-api` as opposed to the `mtd-api-sa-stub`.